### PR TITLE
Use a list item factory instead of a set of ListBoxes

### DIFF
--- a/data/resources.gresource.xml
+++ b/data/resources.gresource.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
     <gresource prefix="/org/itzswirlz/stox/">
+        <file compressed="true" preprocess="xml-stripblanks">resources/ui/menu.ui</file>
         <file compressed="true" preprocess="xml-stripblanks">resources/ui/stoxsidebaritem.ui</file>
     </gresource>
 </gresources>

--- a/data/resources/ui/menu.ui
+++ b/data/resources/ui/menu.ui
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<interface>
+    <menu id='app-menu'>
+        <section>
+            <item>
+                <attribute name='label' translatable='yes'>About Stox</attribute>
+                <attribute name='action'>app.about</attribute>
+            </item>
+        </section>
+    </menu>
+</interface>

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,16 +198,39 @@ fn build_ui(app: &Application, default_symbol: Option<String>) {
     let sidebar = ListBox::new();
     sidebar.set_height_request(800);
     sidebar.append(&searchbar_row);
-    if sidebar_show_separators {
-        sidebar.set_show_separators(true);
-    }
 
     let sidebar_symbols: Arc<Mutex<Vec<StoxSidebarItem>>> = Arc::new(Mutex::new(Vec::new()));
     for symbol in &*saved_stocks.borrow() {
         let sidebar_item = StoxSidebarItem::new(symbol, false);
-        sidebar_item.show();
-        sidebar.append(&sidebar_item);
         sidebar_symbols.lock().unwrap().push(sidebar_item);
+    }
+
+    let model = gio::ListStore::new(StoxSidebarItem::static_type());
+    model.extend_from_slice(&sidebar_symbols.lock().unwrap());
+
+    let factory = SignalListItemFactory::new();
+    factory.connect_setup(move |_, list_item| {
+        list_item
+            .downcast_ref::<ListItem>()
+            .expect("Needs to be ListItem");
+    });
+
+    factory.connect_bind(move |_, list_item| {
+        let sidebar_item = list_item
+            .downcast_ref::<ListItem>()
+            .expect("Needs to be ListItem")
+            .item()
+            .and_downcast::<StoxSidebarItem>()
+            .expect("The item has to be a StoxSidebarItem.");
+        list_item.set_child(Some(&sidebar_item));
+    });
+
+    let selection_model = SingleSelection::new(Some(model));
+    let list_view = ListView::new(Some(selection_model), Some(factory));
+    sidebar.append(&list_view);
+
+    if sidebar_show_separators {
+        list_view.set_show_separators(true);
     }
 
     let (debounce_sender, debounce_receiver) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);


### PR DESCRIPTION
This has a set of advantages. If there is a lot of saved symbols a lot of resources will be used, this ensures only what's needed is visible.

This might make it harder or easier for reordering, filtering and more advanced things with the sidebar.

See https://gtk-rs.org/gtk4-rs/stable/latest/book/list_widgets.html for more